### PR TITLE
Fix redundant URL encoding of branch in edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Redundant URL encoding for branch in edit ([#21](https://github.com/scm-manager/scm-editor-plugin/pull/21))
+
 ## 2.1.0 - 2020-09-09
 ### Added
 - Documentation in English and German ([#17](https://github.com/scm-manager/scm-editor-plugin/pull/17))

--- a/src/main/js/Edit/FileEdit.tsx
+++ b/src/main/js/Edit/FileEdit.tsx
@@ -202,10 +202,7 @@ class FileEdit extends React.Component<Props, State> {
           reject(new Error(t("scm-editor-plugin.errors.branchMissing")));
         }
 
-        const encodedRevision = revision ? encodeURIComponent(revision) : "";
-
-        const pathDefined = path || "";
-        resolve(`${base}${encodedRevision}/${pathDefined}`);
+        resolve(`${base}${revision}/${path}`);
       }
     });
 


### PR DESCRIPTION
## Proposed changes

This redundant encoding lead to a 'not found error' for
edit requests for branches with '/' characters,
because the server got an encoded '%2F' and not a '/'.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [ ] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
