### PR TITLE
Validate path and filename in editor to prevent path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add e2e tests ([#28](https://github.com/scm-manager/scm-editor-plugin/pull/28))
 
+### Fixed
+- Validate path and filename to prevent path traversal ([#30](https://github.com/scm-manager/scm-editor-plugin/pull/30))
+
 ## 2.2.0 - 2020-10-27
 ### Added
 - Source code fullscreen view ([#23](https://github.com/scm-manager/scm-editor-plugin/pull/23))

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@
 
 
 plugins {
-  id 'org.scm-manager.smp' version '0.7.2'
+  id 'org.scm-manager.smp' version '0.8.0'
 }
 
 dependencies {
@@ -39,7 +39,7 @@ dependencies {
 }
 
 scmPlugin {
-  scmVersion = "2.15.1"
+  scmVersion = "2.15.2-SNAPSHOT"
 
   displayName = "Editor"
   description = "Creates, edits and deletes Files"

--- a/src/main/java/com/cloudogu/scm/editor/EditorService.java
+++ b/src/main/java/com/cloudogu/scm/editor/EditorService.java
@@ -33,12 +33,15 @@ import sonia.scm.repository.api.LogCommandBuilder;
 import sonia.scm.repository.api.ModifyCommandBuilder;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
+import sonia.scm.util.ValidationUtil;
 
 import javax.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+
+import static sonia.scm.ScmConstraintViolationException.Builder.doThrow;
 
 public class EditorService {
 
@@ -134,6 +137,14 @@ public class EditorService {
     }
 
     private String computeCompleteFileName(String fileName) {
+      doThrow()
+        .violation("invalid filename: ", fileName)
+        .when(!ValidationUtil.isFilenameValid(fileName));
+
+      doThrow()
+        .violation("invalid path: ", path)
+        .when(!ValidationUtil.isPathValid(path));
+
       if (StringUtils.isEmpty(path)) {
         return fileName;
       } else {

--- a/src/main/js/FileMetaData.tsx
+++ b/src/main/js/FileMetaData.tsx
@@ -32,7 +32,7 @@ const NoBottomMargin = styled.div`
 `;
 
 const PathBlock = styled.div`
-  padding: 0.75em 1em;
+  padding: 1.5em 1em;
   border-bottom: solid 1px #dbdbdb;
   display: flex;
   flex-direction: row;
@@ -125,7 +125,7 @@ class FileMetaData extends React.Component<Props, State> {
       changeFileName(fileName);
       this.setState(
         {
-          filenameValidationError: !fileName
+          filenameValidationError: !validator.isFilenameValid(fileName)
         },
         this.validate
       );


### PR DESCRIPTION
## Proposed changes

Validate path and filename in editor to prevent path traversal.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
