### PR TITLE
New files can be created in empty non-initiated repositories via UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- New files can be created in empty non-initiated repositories ([#39](https://github.com/scm-manager/scm-editor-plugin/pull/39))
+
 ## 2.2.1 - 2021-03-26
 ### Added
 - Add e2e tests ([#28](https://github.com/scm-manager/scm-editor-plugin/pull/28))

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 }
 
 scmPlugin {
-  scmVersion = "2.16.0"
+  scmVersion = "2.20.1-SNAPSHOT"
 
   displayName = "Editor"
   description = "Creates, edits and deletes Files"

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@
 
 
 plugins {
-  id 'org.scm-manager.smp' version '0.8.0'
+  id 'org.scm-manager.smp' version '0.8.3'
 }
 
 dependencies {

--- a/src/main/java/com/cloudogu/scm/editor/BrowserResultLinkEnricher.java
+++ b/src/main/java/com/cloudogu/scm/editor/BrowserResultLinkEnricher.java
@@ -62,7 +62,7 @@ public class BrowserResultLinkEnricher implements HalEnricher {
   }
 
   private boolean isEnrichable(NamespaceAndName namespaceAndName, BrowserResult browserResult) {
-    return preconditions.isEditable(namespaceAndName, browserResult.getRevision(), browserResult.getRequestedRevision()) && isDirectory(browserResult) &&
+    return preconditions.isEditable(namespaceAndName, browserResult) && isDirectory(browserResult) &&
       changeGuardCheck.canCreateFilesIn(namespaceAndName, browserResult.getRequestedRevision(), browserResult.getFile().getPath()).isEmpty();
   }
 

--- a/src/main/java/com/cloudogu/scm/editor/FileLinkEnricher.java
+++ b/src/main/java/com/cloudogu/scm/editor/FileLinkEnricher.java
@@ -57,7 +57,7 @@ public class FileLinkEnricher implements HalEnricher {
     NamespaceAndName namespaceAndName = context.oneRequireByType(NamespaceAndName.class);
     BrowserResult browserResult = context.oneRequireByType(BrowserResult.class);
     FileObject fileObject = context.oneRequireByType(FileObject.class);
-    if (editorPreconditions.isEditable(namespaceAndName, browserResult.getRevision(), browserResult.getRequestedRevision())) {
+    if (editorPreconditions.isEditable(namespaceAndName, browserResult)) {
       appendLinks(appender, fileObject, namespaceAndName, browserResult.getRequestedRevision());
     }
   }

--- a/src/main/js/index.ts
+++ b/src/main/js/index.ts
@@ -45,6 +45,7 @@ const byExtension = (ext: string) => {
 binder.bind("repos.sources.tree.row.right", FileDownloadIcon);
 binder.bind("repos.sources.content.actionbar", ContentActionbar);
 binder.bind("repos.sources.actionbar", SourcesActionbar);
+binder.bind("repos.sources.empty.actionbar", SourcesActionbar);
 binder.bind("repos.sources.extensions", FileUpload, byExtension("upload"));
 binder.bind("repos.sources.extensions", FileEdit, byExtension("edit"));
 binder.bind("repos.sources.extensions", FileEdit, byExtension("create"));

--- a/src/test/java/com/cloudogu/scm/editor/BrowserResultLinkEnricherTest.java
+++ b/src/test/java/com/cloudogu/scm/editor/BrowserResultLinkEnricherTest.java
@@ -79,7 +79,7 @@ class BrowserResultLinkEnricherTest {
     BrowserResult result = createBrowserResult("42", "master", true);
     setUpEnricherContext(repository, result);
 
-    when(preconditions.isEditable(repository.getNamespaceAndName(), "42", "master")).thenReturn(false);
+    when(preconditions.isEditable(repository.getNamespaceAndName(), result)).thenReturn(false);
 
     enricher.enrich(context, appender);
 
@@ -92,7 +92,7 @@ class BrowserResultLinkEnricherTest {
     BrowserResult result = createBrowserResult("42", "master", true);
     setUpEnricherContext(repository, result);
 
-    when(preconditions.isEditable(repository.getNamespaceAndName(), "42", "master")).thenReturn(true);
+    when(preconditions.isEditable(repository.getNamespaceAndName(), result)).thenReturn(true);
     when(changeGuardCheck.canCreateFilesIn(repository.getNamespaceAndName(), "master", null)).thenReturn(singleton(null));
 
     enricher.enrich(context, appender);
@@ -106,7 +106,7 @@ class BrowserResultLinkEnricherTest {
     BrowserResult result = createBrowserResult("42", "master", false);
     setUpEnricherContext(repository, result);
 
-    when(preconditions.isEditable(repository.getNamespaceAndName(), "42", "master")).thenReturn(false);
+    when(preconditions.isEditable(repository.getNamespaceAndName(), result)).thenReturn(false);
 
     enricher.enrich(context, appender);
 
@@ -119,7 +119,7 @@ class BrowserResultLinkEnricherTest {
     BrowserResult result = createBrowserResult("42", "master", true);
     setUpEnricherContext(repository, result);
 
-    when(preconditions.isEditable(repository.getNamespaceAndName(), "42", "master")).thenReturn(true);
+    when(preconditions.isEditable(repository.getNamespaceAndName(), result)).thenReturn(true);
 
     enricher.enrich(context, appender);
 


### PR DESCRIPTION
## Proposed changes

New files can be created in empty non-initiated repositories via the interface. The necessary endpoint was created in scm-manager/scm-manager/pull/1717. 

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
