### PR TITLE
Fix editable files on non-head revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
-- Fix path encoding when working with files ([#42](https://github.com/scm-manager/scm-editor-plugin/pull/42))
+- Path encoding when working with files ([#42](https://github.com/scm-manager/scm-editor-plugin/pull/42))
+- Edit buttons on non-head revisions ([#43](https://github.com/scm-manager/scm-manager/pull/43))
 
 ## 2.3.0 - 2021-07-21
 ### Added

--- a/src/main/java/com/cloudogu/scm/editor/EditorPreconditions.java
+++ b/src/main/java/com/cloudogu/scm/editor/EditorPreconditions.java
@@ -23,6 +23,7 @@
  */
 package com.cloudogu.scm.editor;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.ContextEntry;
@@ -71,7 +72,8 @@ class EditorPreconditions {
   }
 
   private boolean isEmptyRepository(BrowserResult browserResult) {
-    return browserResult.getFile() == null || browserResult.getFile().getChildren().size() == 0;
+    return browserResult.getFile() == null ||
+      browserResult.getFile().isDirectory() && StringUtils.isEmpty(browserResult.getFile().getParentPath()) && browserResult.getFile().getChildren().size() == 0;
   }
 
   private boolean isModifySupported(RepositoryService repositoryService) {

--- a/src/test/java/com/cloudogu/scm/editor/EditorPreconditionsTest.java
+++ b/src/test/java/com/cloudogu/scm/editor/EditorPreconditionsTest.java
@@ -180,9 +180,19 @@ class EditorPreconditionsTest {
   void shouldReturnTrueIfHasTipButEmptyRepo() {
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
     BrowserResult result = createBrowserResult("abc", "tip", false);
+    result.getFile().setDirectory(true);
     setUpPermission("21", true);
 
     assertThat(preconditions.isEditable(namespaceAndName, result)).isTrue();
+  }
+
+  @Test
+  void shouldReturnFalseIfIsNotTipButIsFile() {
+    NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
+    BrowserResult result = createBrowserResult("abc", "123", false);
+    setUpPermission("21", true);
+
+    assertThat(preconditions.isEditable(namespaceAndName, result)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes

Fixes the visibility of edit buttons on revisions, that are not editable (i.e. that are no head revisions of branches or the repository).

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
