### PR TITLE
Fix over fetching of content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Multiple fetches of content type ([#47](https://github.com/scm-manager/scm-editor-plugin/pull/47))
+
 ## 2.4.0 - 2021-10-07
 ### Changed
 - EditorPreconditions and ChangeGuardCheck are now public api ([#46](https://github.com/scm-manager/scm-editor-plugin/pull/46))

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@scm-manager/eslint-config": "^2.12.0",
         "@scm-manager/integration-test-runner": "^1.3.7",
         "@scm-manager/jest-preset": "^2.12.7",
-        "@scm-manager/plugin-scripts": "1.0.2",
+        "@scm-manager/plugin-scripts": "^1.1.0",
         "@scm-manager/prettier-config": "^2.10.1",
         "@scm-manager/tsconfig": "^2.12.0-20201109-093624",
         "@scm-manager/ui-scripts": "^2.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,10 +2797,10 @@
     jest-junit "^12.0.0"
     regenerator-runtime "^0.13.7"
 
-"@scm-manager/plugin-scripts@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@scm-manager/plugin-scripts/-/plugin-scripts-1.0.2.tgz#a445c92329bd11facb069dbe26066414edcd71e2"
-  integrity sha512-e5T7lP64kFmlnXJ7WAGAuRBigWtTndd+T7jQkm6L9oelX/6v/09p0hSIyjTM9AGARxxukoRCa03TjaNFnlverA==
+"@scm-manager/plugin-scripts@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@scm-manager/plugin-scripts/-/plugin-scripts-1.1.0.tgz#177373361579d0dd37cff40780951f73e32ac687"
+  integrity sha512-oIS088kF6X4V7k3kQ0wJ8AWbt1kIrul5OAMRrCNrEpYDkPBYey6s7jW6V1sj2R5Hj/y2+PaEXlc9P0SLFB5+Og==
   dependencies:
     babel-loader "^8.0.6"
     css-loader "^3.2.0"


### PR DESCRIPTION
## Proposed changes

Use hook of @scm-manager/ui-api to fetch the content type in order to avoid multiple fetches of the content type.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
