### PR TITLE
Feature/replace download actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 }
 
 scmPlugin {
-  scmVersion = "2.21.0"
+  scmVersion = "2.25.1-SNAPSHOT"
 
   displayName = "Editor"
   description = "Creates, edits and deletes Files"

--- a/gradle/changelog/extension_points.yaml
+++ b/gradle/changelog/extension_points.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Add extension points for download and upload actions ([#49](https://github.com/scm-manager/scm-editor-plugin/pull/49))

--- a/gradle/changelog/extension_points.yaml
+++ b/gradle/changelog/extension_points.yaml
@@ -1,2 +1,4 @@
 - type: added
   description: Add extension points for download and upload actions ([#49](https://github.com/scm-manager/scm-editor-plugin/pull/49))
+- type: added
+  description: Support for locked files ([#49](https://github.com/scm-manager/scm-editor-plugin/pull/49))

--- a/src/main/java/com/cloudogu/scm/editor/EditorPreconditions.java
+++ b/src/main/java/com/cloudogu/scm/editor/EditorPreconditions.java
@@ -70,12 +70,12 @@ public class EditorPreconditions {
   private boolean isEditableCheck(RepositoryService repositoryService, BrowserResult browserResult) throws IOException {
     return isPermitted(repositoryService.getRepository())
       && isModifySupported(repositoryService)
-      && isLockedByMe(repositoryService, browserResult)
+      && isUnlockedOrLockedByMe(repositoryService, browserResult)
       && (isHeadRevision(repositoryService, browserResult.getRevision(), browserResult.getRequestedRevision())
       || isEmptyRepository(browserResult));
   }
 
-  private boolean isLockedByMe(RepositoryService repositoryService, BrowserResult browserResult) {
+  private boolean isUnlockedOrLockedByMe(RepositoryService repositoryService, BrowserResult browserResult) {
     Optional<FileLock> fileLock = repositoryService.getLockCommand().status(browserResult.getFile().getPath());
     return !fileLock.isPresent() || fileLock.get().getUserId().equals(SecurityUtils.getSubject().getPrincipal().toString());
   }
@@ -84,7 +84,7 @@ public class EditorPreconditions {
     return browserResult.getFile() == null ||
       browserResult.getFile().isDirectory() &&
         StringUtils.isEmpty(browserResult.getFile().getParentPath()) &&
-        browserResult.getFile().getChildren().size() == 0;
+        browserResult.getFile().getChildren().isEmpty();
   }
 
   private boolean isModifySupported(RepositoryService repositoryService) {

--- a/src/main/java/com/cloudogu/scm/editor/EditorPreconditions.java
+++ b/src/main/java/com/cloudogu/scm/editor/EditorPreconditions.java
@@ -76,7 +76,7 @@ public class EditorPreconditions {
   }
 
   private boolean isUnlockedOrLockedByMe(RepositoryService repositoryService, BrowserResult browserResult) {
-    if (repositoryService.isSupported(Command.LOCK)) {
+    if (repositoryService.isSupported(Command.FILE_LOCK)) {
       Optional<FileLock> fileLock = repositoryService.getLockCommand().status(browserResult.getFile().getPath());
       return !fileLock.isPresent() || fileLock.get().getUserId().equals(SecurityUtils.getSubject().getPrincipal().toString());
     }

--- a/src/main/java/com/cloudogu/scm/editor/EditorPreconditions.java
+++ b/src/main/java/com/cloudogu/scm/editor/EditorPreconditions.java
@@ -76,8 +76,11 @@ public class EditorPreconditions {
   }
 
   private boolean isUnlockedOrLockedByMe(RepositoryService repositoryService, BrowserResult browserResult) {
-    Optional<FileLock> fileLock = repositoryService.getLockCommand().status(browserResult.getFile().getPath());
-    return !fileLock.isPresent() || fileLock.get().getUserId().equals(SecurityUtils.getSubject().getPrincipal().toString());
+    if (repositoryService.isSupported(Command.LOCK)) {
+      Optional<FileLock> fileLock = repositoryService.getLockCommand().status(browserResult.getFile().getPath());
+      return !fileLock.isPresent() || fileLock.get().getUserId().equals(SecurityUtils.getSubject().getPrincipal().toString());
+    }
+    return true;
   }
 
   private boolean isEmptyRepository(BrowserResult browserResult) {

--- a/src/main/js/ContentActionbar.tsx
+++ b/src/main/js/ContentActionbar.tsx
@@ -22,11 +22,10 @@
  * SOFTWARE.
  */
 import React from "react";
-import { Repository, File } from "@scm-manager/ui-types";
+import { File, Repository } from "@scm-manager/ui-types";
 import FileDeleteButton from "./Delete/FileDeleteButton";
 import FileEditButton from "./Edit/FileEditButton";
 import FileDownloadButton from "./Download/FileDownloadButton";
-import { ButtonGroup } from "@scm-manager/ui-components";
 
 type Props = {
   repository: Repository;
@@ -39,11 +38,11 @@ class ContentActionbar extends React.Component<Props> {
   render() {
     const { repository, file, revision, handleExtensionError } = this.props;
     return (
-      <ButtonGroup>
+      <div className="field is-grouped">
         <FileDeleteButton file={file} handleExtensionError={handleExtensionError} revision={revision} />
         <FileEditButton repository={repository} revision={revision} file={file} />
         <FileDownloadButton repository={repository} file={file} />
-      </ButtonGroup>
+      </div>
     );
   }
 }

--- a/src/main/js/ContentActionbar.tsx
+++ b/src/main/js/ContentActionbar.tsx
@@ -42,7 +42,7 @@ class ContentActionbar extends React.Component<Props> {
       <ButtonGroup>
         <FileDeleteButton file={file} handleExtensionError={handleExtensionError} revision={revision} />
         <FileEditButton repository={repository} revision={revision} file={file} />
-        <FileDownloadButton file={file} />
+        <FileDownloadButton repository={repository} file={file} />
       </ButtonGroup>
     );
   }

--- a/src/main/js/Delete/FileDeleteButton.tsx
+++ b/src/main/js/Delete/FileDeleteButton.tsx
@@ -112,6 +112,10 @@ class FileDeleteButton extends React.Component<Props, State> {
     const { file, t } = this.props;
     const { showModal, loading } = this.state;
 
+    if (!this.shouldRender()) {
+      return null;
+    }
+
     const modal = showModal ? (
       <FileDeleteModal onClose={this.toggleModal} onCommit={this.deleteFile} file={file} loading={loading} />
     ) : null;
@@ -119,16 +123,14 @@ class FileDeleteButton extends React.Component<Props, State> {
     return (
       <>
         <Pointer>{modal}</Pointer>
-        {this.shouldRender() && (
-          <Button
-            title={t("scm-editor-plugin.delete.tooltip")}
-            className="button"
-            onClick={this.toggleModal}
-            {...createAttributesForTesting("delete-file-button")}
-          >
-            <i className="fas fa-trash" />
-          </Button>
-        )}
+        <Button
+          title={t("scm-editor-plugin.delete.tooltip")}
+          className="button"
+          onClick={this.toggleModal}
+          {...createAttributesForTesting("delete-file-button")}
+        >
+          <i className="fas fa-trash" />
+        </Button>
       </>
     );
   }

--- a/src/main/js/Download/FileDownloadButton.tsx
+++ b/src/main/js/Download/FileDownloadButton.tsx
@@ -23,7 +23,7 @@
  */
 import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
-import { File, Link } from "@scm-manager/ui-types";
+import { File, Link, Repository } from "@scm-manager/ui-types";
 import styled from "styled-components";
 import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
 
@@ -36,14 +36,15 @@ const Button = styled.a`
 `;
 
 type Props = {
+  repository: Repository;
   file: File;
 };
 
-const FileDownloadButton: FC<Props> = ({ file }) => {
+const FileDownloadButton: FC<Props> = ({ repository, file }) => {
   const [t] = useTranslation("plugins");
 
   if (binder.hasExtension("repos.sources.content.actionbar.download")) {
-    return <ExtensionPoint name="repos.sources.content.actionbar.download" props={{ file }} renderAll={false} />;
+    return <ExtensionPoint name="repos.sources.content.actionbar.download" props={{ repository, file }} renderAll={false} />;
   }
   return (
     <Button

--- a/src/main/js/Download/FileDownloadButton.tsx
+++ b/src/main/js/Download/FileDownloadButton.tsx
@@ -25,7 +25,7 @@ import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { File, Link, Repository } from "@scm-manager/ui-types";
 import styled from "styled-components";
-import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
+import { ExtensionPoint } from "@scm-manager/ui-extensions";
 
 const Button = styled.a`
   width: 50px;
@@ -43,18 +43,17 @@ type Props = {
 const FileDownloadButton: FC<Props> = ({ repository, file }) => {
   const [t] = useTranslation("plugins");
 
-  if (binder.hasExtension("repos.sources.content.actionbar.download")) {
-    return <ExtensionPoint name="repos.sources.content.actionbar.download" props={{ repository, file }} renderAll={false} />;
-  }
   return (
-    <Button
-      title={t("scm-editor-plugin.download.tooltip")}
-      className="button"
-      href={(file._links.self as Link).href}
-      download={file.name}
-    >
-      <i className="fas fa-download" />
-    </Button>
+    <ExtensionPoint name="repos.sources.content.actionbar.download" props={{ repository, file }} renderAll={false}>
+      <Button
+        title={t("scm-editor-plugin.download.tooltip")}
+        className="button"
+        href={(file._links.self as Link).href}
+        download={file.name}
+      >
+        <i className="fas fa-download" />
+      </Button>
+    </ExtensionPoint>
   );
 };
 

--- a/src/main/js/Download/FileDownloadButton.tsx
+++ b/src/main/js/Download/FileDownloadButton.tsx
@@ -21,36 +21,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React from "react";
-import { WithTranslation, withTranslation } from "react-i18next";
-import { File } from "@scm-manager/ui-types";
+import React, { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { File, Link } from "@scm-manager/ui-types";
 import styled from "styled-components";
+import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
 
 const Button = styled.a`
   width: 50px;
+
   &:hover {
     color: #33b2e8;
   }
 `;
 
-type Props = WithTranslation & {
+type Props = {
   file: File;
 };
 
-class FileDownloadButton extends React.Component<Props> {
-  render() {
-    const { file, t } = this.props;
-    return (
-      <Button
-        title={t("scm-editor-plugin.download.tooltip")}
-        className="button"
-        href={file._links.self.href}
-        download={file.name}
-      >
-        <i className="fas fa-download" />
-      </Button>
-    );
-  }
-}
+const FileDownloadButton: FC<Props> = ({ file }) => {
+  const [t] = useTranslation("plugins");
 
-export default withTranslation("plugins")(FileDownloadButton);
+  if (binder.hasExtension("repos.sources.content.actionbar.download")) {
+    return <ExtensionPoint name="repos.sources.content.actionbar.download" props={{ file }} renderAll={false} />;
+  }
+  return (
+    <Button
+      title={t("scm-editor-plugin.download.tooltip")}
+      className="button"
+      href={(file._links.self as Link).href}
+      download={file.name}
+    >
+      <i className="fas fa-download" />
+    </Button>
+  );
+};
+
+export default FileDownloadButton;

--- a/src/main/js/Download/FileDownloadIcon.tsx
+++ b/src/main/js/Download/FileDownloadIcon.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import React, { FC } from "react";
-import { File, Link } from "@scm-manager/ui-types";
+import { File, Link, Repository } from "@scm-manager/ui-types";
 import styled from "styled-components";
 import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
 
@@ -34,12 +34,13 @@ const Icon = styled.a`
 `;
 
 type Props = {
+  repository: Repository;
   file: File;
 };
 
-const FileDownloadIcon: FC<Props> = ({ file }) => {
+const FileDownloadIcon: FC<Props> = ({ repository, file }) => {
   if (binder.hasExtension("repos.sources.actionbar.download")) {
-    return <ExtensionPoint name="repos.sources.actionbar.download" props={{ file }} renderAll={false} />;
+    return <ExtensionPoint name="repos.sources.actionbar.download" props={{ repository, file }} renderAll={false} />;
   }
 
   return (

--- a/src/main/js/Download/FileDownloadIcon.tsx
+++ b/src/main/js/Download/FileDownloadIcon.tsx
@@ -21,8 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React from "react";
+import React, { FC } from "react";
+import { File, Link } from "@scm-manager/ui-types";
 import styled from "styled-components";
+import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
 
 const Icon = styled.a`
   color: #33b2e8;
@@ -32,20 +34,21 @@ const Icon = styled.a`
 `;
 
 type Props = {
-  file: any;
+  file: File;
 };
 
-class FileDownloadIcon extends React.Component<Props> {
-  render() {
-    const { file } = this.props;
-    return (
-      <>
-        <Icon href={file._links.self.href} download={file.name}>
-          <i className="fas fa-download" />
-        </Icon>
-      </>
-    );
+const FileDownloadIcon: FC<Props> = ({ file }) => {
+  if (binder.hasExtension("repos.sources.actionbar.download")) {
+    return <ExtensionPoint name="repos.sources.actionbar.download" props={{ file }} renderAll={false} />;
   }
-}
+
+  return (
+    <>
+      <Icon href={(file._links.self as Link).href} download={file.name}>
+        <i className="fas fa-download" />
+      </Icon>
+    </>
+  );
+};
 
 export default FileDownloadIcon;

--- a/src/main/js/Download/FileDownloadIcon.tsx
+++ b/src/main/js/Download/FileDownloadIcon.tsx
@@ -24,7 +24,7 @@
 import React, { FC } from "react";
 import { File, Link, Repository } from "@scm-manager/ui-types";
 import styled from "styled-components";
-import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
+import { ExtensionPoint } from "@scm-manager/ui-extensions";
 
 const Icon = styled.a`
   color: #33b2e8;
@@ -39,16 +39,12 @@ type Props = {
 };
 
 const FileDownloadIcon: FC<Props> = ({ repository, file }) => {
-  if (binder.hasExtension("repos.sources.actionbar.download")) {
-    return <ExtensionPoint name="repos.sources.actionbar.download" props={{ repository, file }} renderAll={false} />;
-  }
-
   return (
-    <>
+    <ExtensionPoint name="repos.sources.actionbar.download" props={{ repository, file }} renderAll={false}>
       <Icon href={(file._links.self as Link).href} download={file.name}>
         <i className="fas fa-download" />
       </Icon>
-    </>
+    </ExtensionPoint>
   );
 };
 

--- a/src/main/js/Edit/FileEditButton.tsx
+++ b/src/main/js/Edit/FileEditButton.tsx
@@ -62,19 +62,19 @@ const FileEditButton: FC<Props> = ({ repository, revision, file }) => {
     history.push(url);
   };
 
+  if (!shouldRender()) {
+    return null;
+  }
+
   return (
-    <>
-      {shouldRender() && (
-        <Button
-          title={t("scm-editor-plugin.edit.tooltip")}
-          className="button"
-          onClick={pushToEditPage}
-          {...createAttributesForTesting("edit-file-button")}
-        >
-          <i className="fas fa-edit" />
-        </Button>
-      )}
-    </>
+    <Button
+      title={t("scm-editor-plugin.edit.tooltip")}
+      className="button"
+      onClick={pushToEditPage}
+      {...createAttributesForTesting("edit-file-button")}
+    >
+      <i className="fas fa-edit" />
+    </Button>
   );
 };
 

--- a/src/main/js/Upload/FileUpload.tsx
+++ b/src/main/js/Upload/FileUpload.tsx
@@ -225,7 +225,7 @@ class FileUpload extends React.Component<Props, State> {
         )}
         <ExtensionPoint
           name="editorPlugin.file.upload.validation"
-          props={{ repository, files, path, isValid: (disable: boolean) => this.setState({ valid: disable }) }}
+          props={{ repository, files, path, validateFiles: (disable: boolean) => this.setState({ valid: disable }) }}
         />
         {error && <ErrorNotification error={error} />}
         <CommitMessage commitMessage={commitMessage} onChange={this.changeCommitMessage} disabled={loading} />

--- a/src/main/js/Upload/FileUpload.tsx
+++ b/src/main/js/Upload/FileUpload.tsx
@@ -52,22 +52,24 @@ const Border = styled.div`
   .section:active {
     box-shadow: none;
   }
+
   ,
-  &:focus-within {
+&: focus-within {
     border-color: #33b2e8;
     box-shadow: 0 0 0 0.125em rgba(51, 178, 232, 0.25);
+
     &:hover {
       border-color: #33b2e8;
     }
   }
   ,
-  &:hover {
+&: hover {
     border: 1px solid #b5b5b5;
     border-radius: 4px;
   }
   ,
-  & .input,
-  .textarea {
+  & . input,
+  . textarea {
     border-color: #dbdbdb;
   }
 `;
@@ -110,11 +112,9 @@ class FileUpload extends React.Component<Props, State> {
     });
   };
 
-  handleFile = files => {
-    const fileArray = this.state.files ? this.state.files : [];
-    files.forEach(file => fileArray.push(file));
+  handleFile = (files: File[]) => {
     this.setState({
-      files: fileArray
+      files: [...this.state.files, ...files]
     });
   };
 
@@ -225,7 +225,7 @@ class FileUpload extends React.Component<Props, State> {
         )}
         <ExtensionPoint
           name="editorPlugin.file.upload.validation"
-          props={{ repository, files, isValid: (disable: boolean) => this.setState({ valid: disable }) }}
+          props={{ repository, files, path, isValid: (disable: boolean) => this.setState({ valid: disable }) }}
         />
         {error && <ErrorNotification error={error} />}
         <CommitMessage commitMessage={commitMessage} onChange={this.changeCommitMessage} disabled={loading} />

--- a/src/test/java/com/cloudogu/scm/editor/EditorPreconditionsTest.java
+++ b/src/test/java/com/cloudogu/scm/editor/EditorPreconditionsTest.java
@@ -196,6 +196,7 @@ class EditorPreconditionsTest {
   void shouldReturnTrueIfFileLockedByMe() {
     LockCommandBuilder lockCommandBuilder = mock(LockCommandBuilder.class);
     when(repositoryService.getLockCommand()).thenReturn(lockCommandBuilder);
+    lenient().when(repositoryService.isSupported(Command.LOCK)).thenReturn(true);
     when(lockCommandBuilder.status("some_file")).thenReturn(Optional.of(new FileLock("some_file", "", "trillian", Instant.now())));
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
     BrowserResult result = createBrowserResult("abc", "tip", false);
@@ -210,6 +211,7 @@ class EditorPreconditionsTest {
   void shouldReturnFalseIfFileLockedNotByMe() {
     LockCommandBuilder lockCommandBuilder = mock(LockCommandBuilder.class);
     when(repositoryService.getLockCommand()).thenReturn(lockCommandBuilder);
+    lenient().when(repositoryService.isSupported(Command.LOCK)).thenReturn(true);
     when(lockCommandBuilder.status("some_file")).thenReturn(Optional.of(new FileLock("some_file", "", "dent", Instant.now())));
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
     BrowserResult result = createBrowserResult("abc", "tip", false);

--- a/src/test/java/com/cloudogu/scm/editor/EditorPreconditionsTest.java
+++ b/src/test/java/com/cloudogu/scm/editor/EditorPreconditionsTest.java
@@ -45,7 +45,7 @@ import sonia.scm.repository.Repository;
 import sonia.scm.repository.RepositoryTestData;
 import sonia.scm.repository.api.Command;
 import sonia.scm.repository.api.FileLock;
-import sonia.scm.repository.api.LockCommandBuilder;
+import sonia.scm.repository.api.FileLockCommandBuilder;
 import sonia.scm.repository.api.LogCommandBuilder;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
@@ -194,9 +194,9 @@ class EditorPreconditionsTest {
   @Test
   @SubjectAware(value = "trillian", permissions = "repository:push:21")
   void shouldReturnTrueIfFileLockedByMe() {
-    LockCommandBuilder lockCommandBuilder = mock(LockCommandBuilder.class);
+    FileLockCommandBuilder lockCommandBuilder = mock(FileLockCommandBuilder.class);
     when(repositoryService.getLockCommand()).thenReturn(lockCommandBuilder);
-    lenient().when(repositoryService.isSupported(Command.LOCK)).thenReturn(true);
+    lenient().when(repositoryService.isSupported(Command.FILE_LOCK)).thenReturn(true);
     when(lockCommandBuilder.status("some_file")).thenReturn(Optional.of(new FileLock("some_file", "", "trillian", Instant.now())));
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
     BrowserResult result = createBrowserResult("abc", "tip", false);
@@ -209,9 +209,9 @@ class EditorPreconditionsTest {
   @Test
   @SubjectAware(value = "trillian", permissions = "repository:push:21")
   void shouldReturnFalseIfFileLockedNotByMe() {
-    LockCommandBuilder lockCommandBuilder = mock(LockCommandBuilder.class);
+    FileLockCommandBuilder lockCommandBuilder = mock(FileLockCommandBuilder.class);
     when(repositoryService.getLockCommand()).thenReturn(lockCommandBuilder);
-    lenient().when(repositoryService.isSupported(Command.LOCK)).thenReturn(true);
+    lenient().when(repositoryService.isSupported(Command.FILE_LOCK)).thenReturn(true);
     when(lockCommandBuilder.status("some_file")).thenReturn(Optional.of(new FileLock("some_file", "", "dent", Instant.now())));
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
     BrowserResult result = createBrowserResult("abc", "tip", false);

--- a/src/test/java/com/cloudogu/scm/editor/EditorPreconditionsTest.java
+++ b/src/test/java/com/cloudogu/scm/editor/EditorPreconditionsTest.java
@@ -24,10 +24,8 @@
 package com.cloudogu.scm.editor;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.shiro.subject.Subject;
-import org.apache.shiro.util.ThreadContext;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.github.sdorra.jse.ShiroExtension;
+import org.github.sdorra.jse.SubjectAware;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -46,20 +44,26 @@ import sonia.scm.repository.Person;
 import sonia.scm.repository.Repository;
 import sonia.scm.repository.RepositoryTestData;
 import sonia.scm.repository.api.Command;
+import sonia.scm.repository.api.FileLock;
+import sonia.scm.repository.api.LockCommandBuilder;
 import sonia.scm.repository.api.LogCommandBuilder;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
+import java.util.Optional;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, ShiroExtension.class})
+@SubjectAware(value = "trillian", permissions = "repository:push:42")
 class EditorPreconditionsTest {
 
   @Mock
@@ -71,24 +75,10 @@ class EditorPreconditionsTest {
   @InjectMocks
   private EditorPreconditions preconditions;
 
-  @Mock
-  private Subject subject;
-
-  @BeforeEach
-  void setUpSubject() {
-    ThreadContext.bind(subject);
-  }
-
-  @AfterEach
-  void tearDownSubject() {
-    ThreadContext.unbindSubject();
-  }
-
   @Test
   void shouldReturnTrueForEmptyRepositoryWithoutBranchSupport() {
     NamespaceAndName namespaceAndName = setUpRepositoryService("42", Command.MODIFY, Command.LOG);
     BrowserResult result = createBrowserResult("abc", "master", false);
-    setUpPermission("42", true);
 
     assertThat(preconditions.isEditable(namespaceAndName, result)).isTrue();
   }
@@ -98,19 +88,16 @@ class EditorPreconditionsTest {
     NamespaceAndName namespaceAndName = setUpRepositoryService("42", Command.MODIFY, Command.LOG);
     BrowserResult result = createBrowserResult("abc", "master", false);
 
-    setUpPermission("42", true);
-
     setUpLogCommandResult("abc");
 
     assertThat(preconditions.isEditable(namespaceAndName, result)).isTrue();
   }
 
   @Test
+  @SubjectAware(value = "trillian", permissions = "repository:push:21")
   void shouldReturnTrueForLatestRevisionOnBranch() throws IOException {
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
     BrowserResult result = createBrowserResult("abc", "master", false);
-
-    setUpPermission("21", true);
 
     setUpBranches(
       Branch.normalBranch("master", "cde"),
@@ -124,25 +111,24 @@ class EditorPreconditionsTest {
   void shouldReturnFalseIfNotPermitted() {
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.LOG, Command.BRANCHES);
     BrowserResult result = createBrowserResult("abc", "master", false);
-    setUpPermission("21", false);
 
     assertThat(preconditions.isEditable(namespaceAndName, result)).isFalse();
   }
 
   @Test
+  @SubjectAware(value = "trillian", permissions = "repository:push:21")
   void shouldReturnFalseIfModifyCommandIsNotSupported() {
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.LOG);
     BrowserResult result = createBrowserResult("abc", "master", false);
-    setUpPermission("21", true);
 
     assertThat(preconditions.isEditable(namespaceAndName, result)).isFalse();
   }
 
   @Test
+  @SubjectAware(value = "trillian", permissions = "repository:push:21")
   void shouldReturnFalseIfLogAndBranchesCommandAreNotSupported() {
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY);
     BrowserResult result = createBrowserResult("abc", "master", false);
-    setUpPermission("21", true);
 
     assertThat(preconditions.isEditable(namespaceAndName, result)).isFalse();
   }
@@ -153,7 +139,6 @@ class EditorPreconditionsTest {
     FileObject fileObject = new FileObject();
     fileObject.addChild(new FileObject());
     BrowserResult result = createBrowserResult("abc", "master", false, fileObject);
-    setUpPermission("42", true);
 
     setUpLogCommandResult("def");
 
@@ -161,12 +146,12 @@ class EditorPreconditionsTest {
   }
 
   @Test
+  @SubjectAware(value = "trillian", permissions = "repository:push:21")
   void shouldReturnFalseIfNotABranch() throws IOException {
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
     FileObject fileObject = new FileObject();
     fileObject.addChild(new FileObject());
     BrowserResult result = createBrowserResult("abc", "notExistingBranch", false, fileObject);
-    setUpPermission("21", true);
 
     setUpBranches(
       Branch.normalBranch("master", "cde"),
@@ -177,20 +162,20 @@ class EditorPreconditionsTest {
   }
 
   @Test
+  @SubjectAware(value = "trillian", permissions = "repository:push:21")
   void shouldReturnTrueIfHasTipButEmptyRepo() {
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
     BrowserResult result = createBrowserResult("abc", "tip", false);
     result.getFile().setDirectory(true);
-    setUpPermission("21", true);
 
     assertThat(preconditions.isEditable(namespaceAndName, result)).isTrue();
   }
 
   @Test
+  @SubjectAware(value = "trillian", permissions = "repository:push:21")
   void shouldReturnFalseIfIsNotTipButIsFile() {
     NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
     BrowserResult result = createBrowserResult("abc", "123", false);
-    setUpPermission("21", true);
 
     assertThat(preconditions.isEditable(namespaceAndName, result)).isFalse();
   }
@@ -199,12 +184,39 @@ class EditorPreconditionsTest {
   void shouldThrowInternalRepositoryExceptionOnError() throws IOException {
     NamespaceAndName namespaceAndName = setUpRepositoryService("42", Command.MODIFY, Command.LOG);
     BrowserResult result = createBrowserResult("abc", "master", false);
-    setUpPermission("42", true);
 
     LogCommandBuilder builder = repositoryService.getLogCommand().setPagingLimit(1);
     doThrow(new IOException("failed :(")).when(builder).getChangesets();
 
     assertThrows(InternalRepositoryException.class, () -> preconditions.isEditable(namespaceAndName, result));
+  }
+
+  @Test
+  @SubjectAware(value = "trillian", permissions = "repository:push:21")
+  void shouldReturnTrueIfFileLockedByMe() {
+    LockCommandBuilder lockCommandBuilder = mock(LockCommandBuilder.class);
+    when(repositoryService.getLockCommand()).thenReturn(lockCommandBuilder);
+    when(lockCommandBuilder.status("some_file")).thenReturn(Optional.of(new FileLock("some_file", "", "trillian", Instant.now())));
+    NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
+    BrowserResult result = createBrowserResult("abc", "tip", false);
+    result.getFile().setDirectory(true);
+    result.getFile().setPath("some_file");
+
+    assertThat(preconditions.isEditable(namespaceAndName, result)).isTrue();
+  }
+
+  @Test
+  @SubjectAware(value = "trillian", permissions = "repository:push:21")
+  void shouldReturnFalseIfFileLockedNotByMe() {
+    LockCommandBuilder lockCommandBuilder = mock(LockCommandBuilder.class);
+    when(repositoryService.getLockCommand()).thenReturn(lockCommandBuilder);
+    when(lockCommandBuilder.status("some_file")).thenReturn(Optional.of(new FileLock("some_file", "", "dent", Instant.now())));
+    NamespaceAndName namespaceAndName = setUpRepositoryService("21", Command.MODIFY, Command.BRANCHES);
+    BrowserResult result = createBrowserResult("abc", "tip", false);
+    result.getFile().setDirectory(true);
+    result.getFile().setPath("some_file");
+
+    assertThat(preconditions.isEditable(namespaceAndName, result)).isFalse();
   }
 
   private BrowserResult createBrowserResult(String revision, String branchName, boolean directory, FileObject fileObject) {
@@ -219,10 +231,6 @@ class EditorPreconditionsTest {
 
   private void setUpBranches(Branch... branches) throws IOException {
     when(repositoryService.getBranchesCommand().getBranches()).thenReturn(new Branches(branches));
-  }
-
-  private void setUpPermission(String repositoryId, boolean permitted) {
-    when(subject.isPermitted("repository:push:" + repositoryId)).thenReturn(permitted);
   }
 
   private void setUpLogCommandResult(String changesetId) throws IOException {


### PR DESCRIPTION
## Proposed changes

Add extension points to replace download actions and to show upload validation warnings.

### Your checklist for this pull request
**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
