### PR TITLE
Fix redirect if folder is empty after deleting a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Redirect to non-empty parent folder or root if folder is empty after deleting a file ([#56](https://github.com/scm-manager/scm-editor-plugin/pull/56))
+
 ## 2.8.0 - 2021-12-22
 ### Added
 - Enable renaming/moving of files and folders ([#55](https://github.com/scm-manager/scm-editor-plugin/pull/55))

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@
 
 
 plugins {
-  id 'org.scm-manager.smp' version '0.10.1'
+  id 'org.scm-manager.smp' version '0.10.2'
 }
 
 dependencies {

--- a/src/main/js/Delete/FileDeleteButton.tsx
+++ b/src/main/js/Delete/FileDeleteButton.tsx
@@ -23,7 +23,7 @@
  */
 import React from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
-import { File, Link } from "@scm-manager/ui-types";
+import { Changeset, File, Link } from "@scm-manager/ui-types";
 import FileDeleteModal from "./FileDeleteModal";
 import { apiClient, createAttributesForTesting, Icon } from "@scm-manager/ui-components";
 import { RouteComponentProps, withRouter } from "react-router-dom";
@@ -71,7 +71,7 @@ class FileDeleteButton extends React.Component<Props, State> {
   };
 
   deleteFile = (commitMessage: string) => {
-    const { file, revision, history, location, handleExtensionError } = this.props;
+    const { revision, handleExtensionError } = this.props;
     this.setState({
       loading: true
     });
@@ -83,35 +83,7 @@ class FileDeleteButton extends React.Component<Props, State> {
       .then(r => r.json())
       .then(async newCommit => {
         if (newCommit) {
-          const newRevision =
-            newCommit._embedded &&
-            newCommit._embedded.branches &&
-            newCommit._embedded.branches[0] &&
-            newCommit._embedded.branches[0].name
-              ? newCommit._embedded.branches[0].name
-              : newCommit.id;
-          const filePath = location.pathname
-            .substr(0, location.pathname.length - file.name.length - 1)
-            .split("/sources/" + revision)[1];
-
-          const filePathParts = filePath.split("/");
-          const checkFolderBaseUrl =
-            (newCommit._links.self as Link).href.split("/changesets/")[0] +
-            `/sources/${encodeURIComponent(newRevision)}`;
-          let exists = false;
-          while (!exists) {
-            try {
-              await apiClient.get(checkFolderBaseUrl + filePathParts.join("/"));
-              exists = true;
-            } catch (err) {
-              filePathParts.pop();
-            }
-          }
-
-          const redirectUrl =
-            location.pathname.split("/sources")[0] +
-            `/sources/${encodeURIComponent(newRevision)}${filePathParts.join("/")}`;
-          history.push(redirectUrl);
+          await this.redirectAfterNewCommit(newCommit);
         }
       })
       .catch(error => {
@@ -119,6 +91,38 @@ class FileDeleteButton extends React.Component<Props, State> {
         handleExtensionError(error);
       });
   };
+
+  async redirectAfterNewCommit(newCommit: Changeset) {
+    const { file, revision, history, location } = this.props;
+
+    const newRevision =
+      newCommit._embedded &&
+      newCommit._embedded.branches &&
+      newCommit._embedded.branches[0] &&
+      newCommit._embedded.branches[0].name
+        ? newCommit._embedded.branches[0].name
+        : newCommit.id;
+    const filePath = location.pathname
+      .substr(0, location.pathname.length - file.name.length - 1)
+      .split("/sources/" + revision)[1];
+
+    const filePathParts = filePath.split("/");
+    const checkFolderBaseUrl =
+      (newCommit._links.self as Link).href.split("/changesets/")[0] + `/sources/${encodeURIComponent(newRevision)}`;
+    let exists = false;
+    while (!exists) {
+      try {
+        await apiClient.get(checkFolderBaseUrl + filePathParts.join("/"));
+        exists = true;
+      } catch (err) {
+        filePathParts.pop();
+      }
+    }
+
+    const redirectUrl =
+      location.pathname.split("/sources")[0] + `/sources/${encodeURIComponent(newRevision)}${filePathParts.join("/")}`;
+    history.push(redirectUrl);
+  }
 
   shouldRender = () => {
     return !!this.props.file._links.delete;


### PR DESCRIPTION
## Proposed changes

Redirecting to a folder failed with a file not found error if the folder was empty after deleting a file, because git and hg are file based and do not know empty folders. We now walk up the directory tree to the first non-empty parent folder or to the repository root and redirect there.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
