### PR TITLE
Fix path inconsistencies for editor, move and upload

### DIFF
--- a/gradle/changelog/fix_editor.yaml
+++ b/gradle/changelog/fix_editor.yaml
@@ -1,2 +1,2 @@
 - type: fixed
-  description: path inconsistencies in the editor ([#70](https://github.com/scm-manager/scm-editor-plugin/pull/70))
+  description: Path inconsistencies for editor, move and upload ([#70](https://github.com/scm-manager/scm-editor-plugin/pull/70))

--- a/gradle/changelog/fix_editor.yaml
+++ b/gradle/changelog/fix_editor.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: path inconsistencies in the editor ([#70](https://github.com/scm-manager/scm-editor-plugin/pull/70))

--- a/src/main/js/Edit/FileEdit.tsx
+++ b/src/main/js/Edit/FileEdit.tsx
@@ -176,7 +176,7 @@ class FileEdit extends React.Component<Props, State> {
   };
 
   afterLoading = () => {
-    const pathWithFilename = this.props.path;
+    const pathWithFilename = decodeURIComponent(this.props.path || "");
     const { initialLoading, path } = this.state;
     const lastPathDelimiter = pathWithFilename?.lastIndexOf("/");
     const parentDirPath = this.isEditMode() ? pathWithFilename?.substr(0, lastPathDelimiter) : pathWithFilename;
@@ -317,6 +317,16 @@ class FileEdit extends React.Component<Props, State> {
     return `/repo/${repository.namespace}/${repository.name}/code/sources`;
   };
 
+  encodePath = (path: string | undefined) => {
+    if (!path) {
+      return "";
+    }
+    return path
+      .split("/")
+      .map(encodeURIComponent)
+      .join("/");
+  };
+
   commitFile = () => {
     const { sources, revision } = this.props;
     const { file, commitMessage, path, content, initialRevision } = this.state;
@@ -329,7 +339,7 @@ class FileEdit extends React.Component<Props, State> {
         type = file.type;
       } else {
         link = (sources._links.upload as Link).href;
-        const pathToReplace = path || "";
+        const pathToReplace = this.encodePath(path);
         link = link.replace("{path}", pathToReplace);
         type = "text/plain";
       }

--- a/src/main/js/Edit/FileEdit.tsx
+++ b/src/main/js/Edit/FileEdit.tsx
@@ -44,6 +44,7 @@ import { encodeFilePath } from "./encodeFilePath";
 import styled from "styled-components";
 import { CodeEditor, findLanguage } from "@scm-manager/scm-code-editor-plugin";
 import { ExtensionPoint } from "@scm-manager/ui-extensions";
+import { setPathInLink } from "../links";
 
 const Header = styled.div`
   line-height: 1.25;
@@ -317,16 +318,6 @@ class FileEdit extends React.Component<Props, State> {
     return `/repo/${repository.namespace}/${repository.name}/code/sources`;
   };
 
-  encodePath = (path: string | undefined) => {
-    if (!path) {
-      return "";
-    }
-    return path
-      .split("/")
-      .map(encodeURIComponent)
-      .join("/");
-  };
-
   commitFile = () => {
     const { sources, revision } = this.props;
     const { file, commitMessage, path, content, initialRevision } = this.state;
@@ -339,8 +330,7 @@ class FileEdit extends React.Component<Props, State> {
         type = file.type;
       } else {
         link = (sources._links.upload as Link).href;
-        const pathToReplace = this.encodePath(path);
-        link = link.replace("{path}", pathToReplace);
+        link = setPathInLink(link, path);
         type = "text/plain";
       }
 

--- a/src/main/js/Edit/FileEdit.tsx
+++ b/src/main/js/Edit/FileEdit.tsx
@@ -177,14 +177,13 @@ class FileEdit extends React.Component<Props, State> {
 
   afterLoading = () => {
     const pathWithFilename = this.props.path;
-    const { file, initialLoading, path } = this.state;
-    const parentDirPath = this.isEditMode()
-      ? pathWithFilename?.replace(encodeURIComponent(file?.name ?? ""), "")
-      : pathWithFilename;
+    const { initialLoading, path } = this.state;
+    const lastPathDelimiter = pathWithFilename?.lastIndexOf("/");
+    const parentDirPath = this.isEditMode() ? pathWithFilename?.substr(0, lastPathDelimiter) : pathWithFilename;
 
-    if ((!path || !pathWithFilename) && parentDirPath !== pathWithFilename) {
+    if (!path) {
       this.setState({
-        path: parentDirPath
+        path: parentDirPath || ""
       });
     }
 

--- a/src/main/js/Edit/FileEdit.tsx
+++ b/src/main/js/Edit/FileEdit.tsx
@@ -329,7 +329,7 @@ class FileEdit extends React.Component<Props, State> {
         type = file.type;
       } else {
         link = (sources._links.upload as Link).href;
-        const pathToReplace = path ? encodeFilePath(path) : "";
+        const pathToReplace = path || "";
         link = link.replace("{path}", pathToReplace);
         type = "text/plain";
       }

--- a/src/main/js/Move/MoveModal.tsx
+++ b/src/main/js/Move/MoveModal.tsx
@@ -56,7 +56,7 @@ const useMoveFolder = () => {
     {
       onSuccess: async (changeset, { repository, moveRequest: { newPath } }) => {
         await queryClient.invalidateQueries(["repository", repository.namespace, repository.name]);
-        const pushPath = createSourceUrlFromChangeset(repository, changeset, encodeURIComponent(newPath.substr(1)));
+        const pushPath = createSourceUrlFromChangeset(repository, changeset, newPath.substr(1));
         history.push(pushPath);
       }
     }

--- a/src/main/js/Upload/FileUpload.tsx
+++ b/src/main/js/Upload/FileUpload.tsx
@@ -100,7 +100,7 @@ class FileUpload extends React.Component<Props, State> {
       loading: false,
       files: [],
       commitMessage: "",
-      path: this.props.path || "",
+      path: decodeURIComponent(this.props.path || ""),
       shouldValidate: true
     };
   }

--- a/src/main/js/Upload/FileUpload.tsx
+++ b/src/main/js/Upload/FileUpload.tsx
@@ -32,9 +32,8 @@ import CommitMessage from "../CommitMessage";
 import FileUploadTable from "./FileUploadTable";
 import styled from "styled-components";
 import { Commit } from "../commit";
-import { createSourceUrl, createSourceUrlFromChangeset } from "../links";
+import { createSourceUrl, createSourceUrlFromChangeset, setPathInLink } from "../links";
 import { ExtensionPoint } from "@scm-manager/ui-extensions";
-import { sanitizePath } from "../pathSanitizer";
 
 const Header = styled.div`
   line-height: 1.25;
@@ -151,7 +150,7 @@ class FileUpload extends React.Component<Props, State> {
     };
 
     apiClient
-      .postBinary(link.replace("{path}", path ? sanitizePath(path) : ""), formdata => {
+      .postBinary(setPathInLink(link, path), formdata => {
         Object.keys(fileAliases).forEach(name => formdata.append(name, fileAliases[name], name));
         formdata.append("commit", JSON.stringify(commit));
       })

--- a/src/main/js/links.ts
+++ b/src/main/js/links.ts
@@ -37,7 +37,7 @@ export function createSourceUrl(repository: Repository, revision?: string, path?
 
 export function createSourceUrlFromChangeset(repository: Repository, changeset: Changeset, path?: string) {
   const revision = getBranchOrId(changeset);
-  return createSourceUrl(repository, revision, sanitizePath(path));
+  return createSourceUrl(repository, revision, encodePath(path));
 }
 
 function getBranchOrId(changeset: Changeset) {
@@ -57,4 +57,19 @@ function append(url: string, revision?: string, path?: string) {
     }
   }
   return url;
+}
+
+export function setPathInLink(link: string, path: string) {
+  const pathToReplace = path ? encodePath(path) : "";
+  return link.replace("{path}", pathToReplace);
+}
+
+function encodePath(path: string | undefined) {
+  if (!path) {
+    return "";
+  }
+  return sanitizePath(path)
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/");
 }


### PR DESCRIPTION
## Proposed changes

This fixes some errors in the editor components:

- When the path contains the filename, this part was removed (the path for the file `/some/file/path/file` was shown as `some//path` for example)
- Files with UTF-8 characters may leed to no path at all
- The editor for a new file does not keep the path where the editor has been opened
- Paths and filenames with `#` led to errors

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
