### PR TITLE
Improve vertical scrolling for smaller screens

### DIFF
--- a/gradle/changelog/vertical_scrolling.yaml
+++ b/gradle/changelog/vertical_scrolling.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Improve vertical scrolling for smaller screens ([#73](https://github.com/scm-manager/scm-editor-plugin/pull/73))

--- a/src/main/js/Edit/FileEdit.tsx
+++ b/src/main/js/Edit/FileEdit.tsx
@@ -83,6 +83,11 @@ const Border = styled.div`
 
 const MarginlessModalContent = styled.div`
   margin: -1.25rem;
+
+  .ace_editor {
+    min-height: 80px;
+    height: calc(97vh - 23rem) !important;
+  }
 `;
 
 type FileWithType = File & {
@@ -441,7 +446,7 @@ class FileEdit extends React.Component<Props, State> {
                 }
                 right={
                   <OpenInFullscreenButton
-                    modalTitle={file?.name}
+                    modalTitle={file?.name || ""}
                     modalBody={<MarginlessModalContent>{body}</MarginlessModalContent>}
                   />
                 }


### PR DESCRIPTION
## Proposed changes

On smaller screens, the horizontal scrollbar in the fullscreen view is only displayed when editing a file as soon as the user scrolls all the way down in the modal. Otherwise, the user can only navigate horizontally using a touchpad or keyboard. With this change, the vertical scrollbar should always be displayed.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [x] UI changes fits into the layout
- [x] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
