### PR TITLE
Modal must not trigger tooltip

### DIFF
--- a/src/main/js/Edit/FileEdit.tsx
+++ b/src/main/js/Edit/FileEdit.tsx
@@ -448,6 +448,7 @@ class FileEdit extends React.Component<Props, State> {
                   <OpenInFullscreenButton
                     modalTitle={file?.name || ""}
                     modalBody={<MarginlessModalContent>{body}</MarginlessModalContent>}
+                    tooltipStyle="htmlTitle"
                   />
                 }
               />


### PR DESCRIPTION
## Proposed changes

Change tooltip style to be no longer triggered by modal which lies directly over the tooltip. This was because the modal was nested inside the tooltip wrapper and after refocus the window the mouse interactions also triggered tooltip active state. Since we already plan to create a new tooltip component I decided to take the workaround by changing the tooltip style. We also use the same style for the content action bar.


### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [ ] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
